### PR TITLE
Small fix to compile on megaavr boards

### DIFF
--- a/Atmega_Board_Detector/ICSP_Utils.ino
+++ b/Atmega_Board_Detector/ICSP_Utils.ino
@@ -301,10 +301,12 @@ void initPins ()
 
   // set up 8 MHz timer on pin 9
   pinMode (CLOCKOUT, OUTPUT);
+#ifndef ARDUINO_ARCH_MEGAAVR
   // set up Timer 1
   TCCR1A = bit (COM1A0);  // toggle OC1A on Compare Match
   TCCR1B = bit (WGM12) | bit (CS10);   // CTC, no prescaling
   OCR1A =  0;       // output every cycle
+#endif
 
 
 

--- a/Atmega_Board_Programmer/ICSP_Utils.ino
+++ b/Atmega_Board_Programmer/ICSP_Utils.ino
@@ -301,10 +301,12 @@ void initPins ()
 
   // set up 8 MHz timer on pin 9
   pinMode (CLOCKOUT, OUTPUT);
+#ifndef ARDUINO_ARCH_MEGAAVR
   // set up Timer 1
   TCCR1A = bit (COM1A0);  // toggle OC1A on Compare Match
   TCCR1B = bit (WGM12) | bit (CS10);   // CTC, no prescaling
   OCR1A =  0;       // output every cycle
+#endif
 
 
 

--- a/Atmega_Hex_Uploader/ICSP_Utils.ino
+++ b/Atmega_Hex_Uploader/ICSP_Utils.ino
@@ -301,10 +301,12 @@ void initPins ()
 
   // set up 8 MHz timer on pin 9
   pinMode (CLOCKOUT, OUTPUT);
+#ifndef ARDUINO_ARCH_MEGAAVR
   // set up Timer 1
   TCCR1A = bit (COM1A0);  // toggle OC1A on Compare Match
   TCCR1B = bit (WGM12) | bit (CS10);   // CTC, no prescaling
   OCR1A =  0;       // output every cycle
+#endif
 
 
 


### PR DESCRIPTION
like Arduino WiFi Rev2. This fix just disables timer start on MEGAAVR architecture. There is a similar timer but it has different set of control registers. Tested on Arduino UNO Wifi Rev2.